### PR TITLE
Add ”Buy tickets” CTAs on Diversity Tickets page

### DIFF
--- a/diversity-support-tickets.html
+++ b/diversity-support-tickets.html
@@ -16,6 +16,13 @@ permalink: /diversity-support-tickets/
 
 <p>You purchase a ticket for yourself, and enable another person of the conference’s choosing to attend the event by paying a share towards their ticket. The support options range from contributing 25%, 50% and up to 100% towards a full ticket. We thank you in advance for your generosity and awesomeness and look forward to a more inclusive CSSconf EU than ever before.</p>
 
+<p class="tac">
+  <a class="link--button link--animated" href="{{ site.ticket_sale_url }}">
+    Buy tickets
+    <span class="link__icon link__icon--rocket">🚀</span>
+  </a>
+</p>
+
 <h2>Why Diversity Support Tickets?</h2>
 
 <p>We believe that only a diverse community is a healthy community, and we welcome and encourage participation by everyone. The Diversity Support Tickets initiative is one attempt to increase the number of participants that would love to attend but are financially or otherwise unable to do so.</p>
@@ -37,3 +44,10 @@ permalink: /diversity-support-tickets/
 <h2>Can I contribute or sponsor in other ways?</h2>
 
 <p>Help from sponsors is greatly needed – if you are interested in supporting CSSconf EU to become more accessible and inclusive, you can <a href="http://sponsoring.cssconf.eu/">read more here</a>, or reach out directly via <a href="mailto:contact@cssconf.eu">e-mail</a>.</p>
+
+<p class="tac">
+  <a class="link--button link--animated" href="{{ site.ticket_sale_url }}">
+    Buy tickets
+    <span class="link__icon link__icon--rocket">🚀</span>
+  </a>
+</p>


### PR DESCRIPTION
## A CTA in the middle:

<img width="793" alt="diversity-tickets-middle" src="https://cloud.githubusercontent.com/assets/11782/21177257/9c8db144-c1ea-11e6-8375-b7ccfae1afb0.png">

## A CTA in the bottom of the page:

<img width="889" alt="diversity-tickets-bottom" src="https://cloud.githubusercontent.com/assets/11782/21177256/9c79481c-c1ea-11e6-9e06-7e5fbe7c42a9.png">