### PR TITLE
:sparkles: Add a partial to promote diversity tickets

### DIFF
--- a/_data/diversity_tickets.yml
+++ b/_data/diversity_tickets.yml
@@ -1,0 +1,10 @@
+- name: Elias Liedholm
+- name: Christopher Astfalk
+- name: always twisted
+- name: Accenture
+- name: Bitcrowd GmbH
+- name: Igalia
+- name: itemis AG
+- name: AgenturWebfox GmbH
+- name: exutec
+- name: 8 Anonymous

--- a/_includes/diversity-tickets-hall-of-fame.html
+++ b/_includes/diversity-tickets-hall-of-fame.html
@@ -1,0 +1,14 @@
+<p class="tac color--mint">
+  We are very grateful and are saying a big Thank You to those companies and individuals who donated to our scholarship program: ❤️
+</p>
+<p class="tac color--mint">
+  {% for supporter in site.data.diversity_tickets %}
+    {{ supporter.name }}{% if forloop.last %}.{% else %},{% endif %}
+  {% endfor %}
+</p>
+<p class="tac">
+  <a class="link--button link--animated" href="{{ site.ticket_sale_url }}">
+    Buy a diversity ticket
+    <span class="link__icon link__icon--rocket">🚀</span>
+  </a>
+</p>

--- a/diversity-support-tickets.html
+++ b/diversity-support-tickets.html
@@ -7,21 +7,12 @@ permalink: /diversity-support-tickets/
 ---
 
 <p class="intro">CSSconf EU strives to create a genuinely welcoming, safe, and inspiring event for the CSS community. This year we’re offering Diversity Support Tickets to allow an even more diverse audience to participate in the conference.</p>
-<!--
-<p>
-  <a href="https://ti.to/cssconfeu/cssconf-eu-2017/" class="link--button">Buy Ticket</a>
-</p> -->
 
 <h2>How do Diversity Support Tickets work?</h2>
 
 <p>You purchase a ticket for yourself, and enable another person of the conference’s choosing to attend the event by paying a share towards their ticket. The support options range from contributing 25%, 50% and up to 100% towards a full ticket. We thank you in advance for your generosity and awesomeness and look forward to a more inclusive CSSconf EU than ever before.</p>
 
-<p class="tac">
-  <a class="link--button link--animated" href="{{ site.ticket_sale_url }}">
-    Buy tickets
-    <span class="link__icon link__icon--rocket">🚀</span>
-  </a>
-</p>
+{% include diversity-tickets-hall-of-fame.html %}
 
 <h2>Why Diversity Support Tickets?</h2>
 

--- a/scholarships.html
+++ b/scholarships.html
@@ -22,6 +22,8 @@ permalink: /scholarships/
   Granting these scholarships is made possible thanks to our <a href="/diversity-support-tickets/">Diversity Support Tickets</a> initiative and the generous contributions made by our <a href="/sponsors">sponsors</a>. More help is needed – talk to us if you’d like to get involved: <a href="mailto:contact@cssconf.eu">contact@cssconf.eu</a>.
 </p>
 
+{% include diversity-tickets-hall-of-fame.html %}
+
 <h2>Application Form</h2>
 
 <p>

--- a/sponsors.html
+++ b/sponsors.html
@@ -25,3 +25,5 @@ permalink: /sponsors/
     </div>
   </div>
 </section>
+
+{% include diversity-tickets-hall-of-fame.html %}


### PR DESCRIPTION
Fixes #51 

The partial has been added to the following pages (click for preview):
- [”Apply for a Scholarship”](https://cloud.githubusercontent.com/assets/11782/22240340/ffcacf1c-e21a-11e6-8a84-aa64da5a1a5d.png)
- [”Diversity Support Tickets”](https://cloud.githubusercontent.com/assets/11782/22240364/2800c3c4-e21b-11e6-88d5-5d6463ea3628.png)
- [”Sponsors”](https://cloud.githubusercontent.com/assets/11782/22240362/26bea742-e21b-11e6-89c5-786dd58d621f.png)

